### PR TITLE
[PATCH] - Hopefully resolving token refresh issues, no more spamming Spotify

### DIFF
--- a/src/app/token/token.service.ts
+++ b/src/app/token/token.service.ts
@@ -33,29 +33,25 @@ export class TokenService extends HttpService<any>{
     expiry_time: number;
 
     authorize(){
-        const token = localStorage.getItem(this.tokenName);
+        localStorage.clear();
 
-        if (!token){
-            this.activatedRoute.queryParams.subscribe(params => {
+        this.activatedRoute.queryParams.subscribe(params => {
 
-                this.accessToken = params['access_token'];
-                this.refreshToken = params['refresh_token'];
-                this.expiry_time = new Date().getTime() + parseInt(Expiries.token) * 1000;
+            this.accessToken = params['access_token'];
+            this.refreshToken = params['refresh_token'];
+            this.expiry_time = new Date().getTime() + parseInt(Expiries.token) * 1000;
 
-                if(this.accessToken){
-                    localStorage.setItem(this.tokenName, this.accessToken);
-                    localStorage.setItem(this.refreshTokenName, this.refreshToken);
-                    localStorage.setItem('expiry_time', this.expiry_time.toString());
+            if(this.accessToken){
+                localStorage.setItem(this.tokenName, this.accessToken);
+                localStorage.setItem(this.refreshTokenName, this.refreshToken);
+                localStorage.setItem('expiry_time', this.expiry_time.toString());
 
-                    return this.accessToken;
-                }
-                else{
-                    this.document.location.href = this.tokenUrl;
-                }
-            })
-        } 
-
-        return token;
+                return this.accessToken;
+            }
+            else{
+                this.document.location.href = this.tokenUrl;
+            }
+        })
     }
 
     refresh(){
@@ -74,7 +70,5 @@ export class TokenService extends HttpService<any>{
             this.expiry_time = Date.now() + (parseInt(Expiries.token) * 1000);
             localStorage.setItem('expiry_time', this.expiry_time.toString());
         });
-
-        return token;
     }
 }


### PR DESCRIPTION
Following KISS principles (Keep It Simple Stupid!) clear the Auth tokens every time the Auth end point is hit. New Auth flow:

- /Auth is hit -> LocalStorage is cleared and user is redirected to Spotify
- User logs in and is redirected back to /Auth
- /Auth is hit -> LocalStorage is still empty but tokens exist in QueryParams
- LocalStorage is updated with tokens and user is redirected into the App where no more storage clearing will occur.